### PR TITLE
round-up on spi read size

### DIFF
--- a/common/spl/spl_fit.c
+++ b/common/spl/spl_fit.c
@@ -204,10 +204,10 @@ static int get_aligned_image_size(struct spl_load_info *info, int data_size,
 {
 	data_size = data_size + get_aligned_image_overhead(info, offset);
 
-	if (info->filename)
-		return data_size;
+	if (!info->filename)
+		data_size = (data_size + info->bl_len - 1) / info->bl_len;
 
-	return (data_size + info->bl_len - 1) / info->bl_len;
+	return roundup(data_size, 4);
 }
 
 /**


### PR DESCRIPTION
When attempting to spi boot the odroid-m1 (and other rk3568 variants) the boot fails with a bad atf-1 hash:
```
  U-Boot SPL 2023.04-00039-g88e32f4527 (May 21 2023 - 19:18:55 -0400)
  Trying to boot from SPI
  ## Checking hash(es) for config config-1 ... OK
  ## Checking hash(es) for Image atf-1 ... sha256 error!
  Bad hash value for 'hash' hash node in 'atf-1' image node
```
This is because the atf-1 spi read tries to read 169795 bytes which corrupts the last three bytes on a mis-aligned read. Using roundup to align to a four byte boundary corrects the issue.
