### PR TITLE
rockchip: rk356x-u-boot: Prioritize SDMMC for SPL boot order

### DIFF
--- a/arch/arm/dts/rk356x-u-boot.dtsi
+++ b/arch/arm/dts/rk356x-u-boot.dtsi
@@ -13,7 +13,7 @@
 	};
 
 	chosen {
-		u-boot,spl-boot-order = "same-as-spl", &sdmmc0, &sdhci;
+		u-boot,spl-boot-order = &sdmmc0, "same-as-spl", &sdhci;
 	};
 
 	dmc: dmc {


### PR DESCRIPTION
@Kwiboo I am following your current great work and all your patches posted on getting Rockchip boards to make use of U-Boot mainline.
I am using this PR just to share my thought on probably prioritizing the SPL boot order for looking to `SDMMC` first, since this is a removable device and this priority would enable to inject a u-boot by SD card to overload soldered devices holding current u-boot - like SPI NOR etc.. - at any time.
